### PR TITLE
Fix SerialPort construction to work with latest serialport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var SerialPort = require('serialport').SerialPort;
+var SerialPort = require('serialport');
 var Duplex = require('stream').Duplex;
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "serialport",
     "serial"
   ],
-  "dependencies" : {
-    "serialport" : ">=1.1.1"
+  "dependencies": {
+    "serialport": ">=6.0.4"
   },
   "devDependencies": {
     "nodeunit": ">=0.7.4"


### PR DESCRIPTION
`serialport` module has changed the way `SerialPort` is constructed several versions ago, which causes `node-s2serial` to break because the dependency downloads the latest version of `serialport`.

This PR simply fixes `SerialPort` construction to work with `serialport@6.0.4` .